### PR TITLE
fix(wifi): ensure key is interpolated and no existing network is configured

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -306,13 +306,14 @@ function configure_network() {
 
         sed -i 's/^Interface=.*/Interface='"$WIFI_INTERFACE"'/' /etc/netctl/wireless-wpa
         sed -i 's/^ESSID=.*/ESSID='"$WIFI_ESSID"'/' /etc/netctl/wireless-wpa
-        sed -i 's/^Key=.*/Key='\''$WIFI_KEY'\''/' /etc/netctl/wireless-wpa
+        sed -i 's/^Key=.*/Key='"$WIFI_KEY"'/' /etc/netctl/wireless-wpa
         if [ "$WIFI_HIDDEN" == "true" ]; then
             sed -i 's/^#Hidden=.*/Hidden=yes/' /etc/netctl/wireless-wpa
         fi
 
+        netctl stop-all
         netctl start wireless-wpa
-        sleep 5
+        sleep 10
     fi
 
     ping -c 5 $PING_HOSTNAME


### PR DESCRIPTION
- Stop all network connections that may be present (Using wifi-menu) before running alis
- Fix quoting of $WIFI_KEY so it is interpolated correctly
- Increase sleep to 10 seconds to allow DNS lookups to succeed