### PR TITLE
Add group 'linux' to pacstrap

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -471,7 +471,7 @@ function install() {
     sed -i 's/#Color/Color/' /etc/pacman.conf
     sed -i 's/#TotalDownload/TotalDownload/' /etc/pacman.conf
 
-    pacstrap /mnt base base-devel
+    pacstrap /mnt base base-devel linux
 
     sed -i 's/#Color/Color/' /mnt/etc/pacman.conf
     sed -i 's/#TotalDownload/TotalDownload/' /mnt/etc/pacman.conf


### PR DESCRIPTION
Today, the Arch Linux developers replaced the 'base' group with a metapackage of the same name.

The new 'base' metapackage doesn't include a kernel, so the installation with this script will fail. This can be easily fixed by adding the 'linux' package to the pacstrap command in alis.sh.

Tested with the latest Arch Linux ISO (2019.10.01) in VMware.

Reference: https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/