### PR TITLE
Add swapon to /swap file

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -450,6 +450,7 @@ function partition() {
         fallocate -l $SWAP_SIZE /mnt/swap
         chmod 600 /mnt/swap
         mkswap /mnt/swap
+        swapon /swap
     fi
 
     BOOT_DIRECTORY=/boot


### PR DESCRIPTION
According to [Swap](https://wiki.archlinux.org/index.php/Swap) page, `swapon` should be called to enable the swap file.