### PR TITLE
Removing user-dirs.locale config setting as it fails during installation

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -875,7 +875,6 @@ function create_user() {
     printf "$USER_PASSWORD\n$USER_PASSWORD" | arch-chroot /mnt passwd $USER_NAME
 
     pacman_install "xdg-user-dirs"
-    arch-chroot /mnt sudo -H -u $USER_NAME echo "$LOCALE" > "/home/$USER_NAME/.config/user-dirs.locale"
     arch-chroot /mnt sudo -H -u $USER_NAME xdg-user-dirs-update
 }
 


### PR DESCRIPTION
That line fails with something like `file not found`. 