### PR TITLE
Manually choose partitions

### DIFF
--- a/alis.conf
+++ b/alis.conf
@@ -4,7 +4,7 @@
 # Some keys accept a single value others accept multiple values as annotated in the comments.
 
 # init
-KEYS="fr"
+KEYS="es"
 LOG="false"
 
 # Partition
@@ -19,10 +19,10 @@ PARTITION_BOOT="/dev/sda1"
 PARTITION_ROOT="/dev/sda2"
 
 DEVICE_TRIM="true" # If DEVICE supports TRIM
-LVM="false" # true if use LVM for partitioning
+LVM="true" # true if use LVM for partitioning
 PARTITION_ROOT_ENCRYPTION_PASSWORD="archlinux" # LUKS encryption key, if LVM will be user LVM on LUKS. Empty for not use LUKS/encryption. Warning: change it!
 PARTITION_ROOT_ENCRYPTION_PASSWORD_RETYPE="archlinux"
-FILE_SYSTEM_TYPE="!ext4 btrfs !xfs" # (single)
+FILE_SYSTEM_TYPE="ext4 !btrfs !xfs" # (single)
 SWAP_SIZE="!2GiB !4GiB !8GiB" # (single)
 
 # network_install
@@ -38,10 +38,10 @@ KERNELS="!linux-lts !linux-lts-headers !linux-hardened !linux-hardened-headers !
 KERNELS_COMPRESSION="!gzip !bzip2 !lzma !xz !lzop !lz4"
 
 # config
-TIMEZONE="/usr/share/zoneinfo/Europe/Paris"
+TIMEZONE="/usr/share/zoneinfo/Europe/Madrid"
 LOCALES=("es_ES.UTF-8 UTF-8" "en_GB.UTF-8 UTF-8")
 LOCALE_CONF=("LANG=es_ES.UTF-8" "LANGUAGE=es_ES:es:en_GB:en")
-KEYMAP="KEYMAP=fr"
+KEYMAP="KEYMAP=es"
 FONT=""
 FONT_MAP=""
 HOSTNAME="archlinux"
@@ -49,17 +49,17 @@ ROOT_PASSWORD="archlinux" # Root user password. Warning: change it!
 ROOT_PASSWORD_RETYPE="archlinux"
 
 # user
-USER_NAME="gazorby"
+USER_NAME="picodotdev"
 USER_PASSWORD="archlinux" # Main user password. Warning: change it!
 USER_PASSWORD_RETYPE="archlinux"
 ADDITIONAL_USER_NAMES="" # list separated by space
 ADDITIONAL_USER_PASSWORDS="" # list separated by space
 
 # mkinitcpio
-HOOKS="base !udev !usr !resume !systemd btrfs keyboard autodetect modconf block !net !dmraid !mdadm !mdadm_udev !keymap !consolefont !sd-vconsole !encrypt !lvm2 !sd-encrypt !sd-lvm2 fsck filesystems"
+HOOKS="base !udev !usr !resume !systemd !btrfs keyboard autodetect modconf block !net !dmraid !mdadm !mdadm_udev !keymap !consolefont !sd-vconsole !encrypt !lvm2 !sd-encrypt !sd-lvm2 fsck filesystems"
 
 # bootloader
-BOOTLOADER="!grub !refind systemd" # (single)
+BOOTLOADER="grub !refind !systemd" # (single)
 
 # desktop
 DESKTOP_ENVIRONMENT="!gnome !kde !xfce !mate !cinnamon !lxde" # (single)

--- a/alis.conf
+++ b/alis.conf
@@ -7,8 +7,17 @@
 KEYS="es"
 LOG="false"
 
-# partition
+# Partition
+ERASE="false" # If true, partitions will be automatically created
+
+# Required if ERASE is true
 DEVICE="/dev/sda !/dev/nvme0n1 !/dev/mmcblk0" # sata nvme mmc (single)
+
+# Required if ERASE is false
+PARTITION_BIOS=""  # let this empty if you have an EFI system
+PARTITION_BOOT="/dev/sda1"
+PARTITION_ROOT="/dev/sda2"
+
 DEVICE_TRIM="true" # If DEVICE supports TRIM
 LVM="true" # true if use LVM for partitioning
 PARTITION_ROOT_ENCRYPTION_PASSWORD="archlinux" # LUKS encryption key, if LVM will be user LVM on LUKS. Empty for not use LUKS/encryption. Warning: change it!

--- a/alis.conf
+++ b/alis.conf
@@ -4,7 +4,7 @@
 # Some keys accept a single value others accept multiple values as annotated in the comments.
 
 # init
-KEYS="es"
+KEYS="fr"
 LOG="false"
 
 # Partition
@@ -19,10 +19,10 @@ PARTITION_BOOT="/dev/sda1"
 PARTITION_ROOT="/dev/sda2"
 
 DEVICE_TRIM="true" # If DEVICE supports TRIM
-LVM="true" # true if use LVM for partitioning
+LVM="false" # true if use LVM for partitioning
 PARTITION_ROOT_ENCRYPTION_PASSWORD="archlinux" # LUKS encryption key, if LVM will be user LVM on LUKS. Empty for not use LUKS/encryption. Warning: change it!
 PARTITION_ROOT_ENCRYPTION_PASSWORD_RETYPE="archlinux"
-FILE_SYSTEM_TYPE="ext4 !btrfs !xfs" # (single)
+FILE_SYSTEM_TYPE="!ext4 btrfs !xfs" # (single)
 SWAP_SIZE="!2GiB !4GiB !8GiB" # (single)
 
 # network_install
@@ -38,10 +38,10 @@ KERNELS="!linux-lts !linux-lts-headers !linux-hardened !linux-hardened-headers !
 KERNELS_COMPRESSION="!gzip !bzip2 !lzma !xz !lzop !lz4"
 
 # config
-TIMEZONE="/usr/share/zoneinfo/Europe/Madrid"
+TIMEZONE="/usr/share/zoneinfo/Europe/Paris"
 LOCALES=("es_ES.UTF-8 UTF-8" "en_GB.UTF-8 UTF-8")
 LOCALE_CONF=("LANG=es_ES.UTF-8" "LANGUAGE=es_ES:es:en_GB:en")
-KEYMAP="KEYMAP=es"
+KEYMAP="KEYMAP=fr"
 FONT=""
 FONT_MAP=""
 HOSTNAME="archlinux"
@@ -49,17 +49,17 @@ ROOT_PASSWORD="archlinux" # Root user password. Warning: change it!
 ROOT_PASSWORD_RETYPE="archlinux"
 
 # user
-USER_NAME="picodotdev"
+USER_NAME="gazorby"
 USER_PASSWORD="archlinux" # Main user password. Warning: change it!
 USER_PASSWORD_RETYPE="archlinux"
 ADDITIONAL_USER_NAMES="" # list separated by space
 ADDITIONAL_USER_PASSWORDS="" # list separated by space
 
 # mkinitcpio
-HOOKS="base !udev !usr !resume !systemd !btrfs keyboard autodetect modconf block !net !dmraid !mdadm !mdadm_udev !keymap !consolefont !sd-vconsole !encrypt !lvm2 !sd-encrypt !sd-lvm2 fsck filesystems"
+HOOKS="base !udev !usr !resume !systemd btrfs keyboard autodetect modconf block !net !dmraid !mdadm !mdadm_udev !keymap !consolefont !sd-vconsole !encrypt !lvm2 !sd-encrypt !sd-lvm2 fsck filesystems"
 
 # bootloader
-BOOTLOADER="grub !refind !systemd" # (single)
+BOOTLOADER="!grub !refind systemd" # (single)
 
 # desktop
 DESKTOP_ENVIRONMENT="!gnome !kde !xfce !mate !cinnamon !lxde" # (single)

--- a/alis.sh
+++ b/alis.sh
@@ -139,6 +139,7 @@ function check_variables() {
     check_variables_boolean "DISPLAY_DRIVER_HARDWARE_ACCELERATION" "$DISPLAY_DRIVER_HARDWARE_ACCELERATION"
     check_variables_list "DISPLAY_DRIVER_HARDWARE_ACCELERATION_INTEL" "$DISPLAY_DRIVER_HARDWARE_ACCELERATION_INTEL" "intel-media-driver libva-intel-driver" "false"
     check_variables_boolean "REBOOT" "$REBOOT"
+    check_variables_value "DEVICE" "$DEVICE"
 
     if [[ $ERASE = false ]]; then
         check_variables_value "PARTITION_BOOT" "$PARTITION_BOOT"
@@ -146,8 +147,6 @@ function check_variables() {
         if [[ $BIOS_TYPE = bios ]]; then
             check_variables_value "PARTITION_BIOS" "$PARTITION_BIOS"
         fi
-    else
-        check_variables_value "DEVICE" "$DEVICE"
     fi
 }
 

--- a/alis.sh
+++ b/alis.sh
@@ -412,7 +412,7 @@ function partition_create() {
     else
         DEVICE_ROOT="${PARTITION_ROOT}"
         wipefs -a $DEVICE_ROOT
-        sgdisk --change-name=${PARTITION_ROOT: -1}:"${PARTITION_ROOT_LABEL}"
+        sgdisk --change-name=${PARTITION_ROOT: -1}:"${PARTITION_ROOT_LABEL}" $DEVICE
     fi
 }
 

--- a/alis.sh
+++ b/alis.sh
@@ -492,7 +492,7 @@ function partition() {
     fi
 
     if [ -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" ]; then
-        echo -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" | cryptsetup --key-size=512 --key-file=- luksFormat --type luks2 $PARTITION_ROOT
+        echo -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" | cryptsetup --key-size=512 --key-file=- --align-payload=8192 -s 256 -c aes-xts-plain64 luksFormat --type luks2 $PARTITION_ROOT
         echo -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" | cryptsetup --key-file=- open $PARTITION_ROOT $LVM_VOLUME_PHISICAL
         sleep 5
     fi

--- a/alis.sh
+++ b/alis.sh
@@ -435,9 +435,9 @@ function partition_format() {
     fi
 
     if [[ "$FILE_SYSTEM_TYPE" == "btrfs" ]]; then
-        mkfs."$FILE_SYSTEM_TYPE" -f --label "$PARTITION_ROOT_LABEL" $DEVICE_ROOT
+        mkfs."$FILE_SYSTEM_TYPE" -f -L "$PARTITION_ROOT_LABEL" $DEVICE_ROOT
     else
-        mkfs."$FILE_SYSTEM_TYPE" --label "$PARTITION_ROOT_LABEL" $DEVICE_ROOT
+        mkfs."$FILE_SYSTEM_TYPE" -L "$PARTITION_ROOT_LABEL" $DEVICE_ROOT
     fi
 }
 

--- a/alis.sh
+++ b/alis.sh
@@ -607,7 +607,7 @@ function mkinitcpio_configuration() {
         pacman_install "btrfs-progs"
     fi
 
-    if ["$BOOTLOADER" == "systemd"]; then
+    if [ "$BOOTLOADER" == "systemd" ]; then
         HOOKS=$(echo $HOOKS | sed 's/!systemd/systemd/')
         if [ "$LVM" == "true" ]; then
             HOOKS=$(echo $HOOKS | sed 's/!sd-lvm2/sd-lvm2/')

--- a/alis.sh
+++ b/alis.sh
@@ -513,6 +513,7 @@ function partition() {
         PARTITION_OPTIONS="$PARTITION_OPTIONS,noatime"
     fi
 
+    partition_mount
     partition_swap
 
     # set variables


### PR DESCRIPTION
A small rework of partitioning part to allow installing without clearing partition table

Four new global variables are introduced :

    ERASE="false"  # If true, partitions will be automatically created

    PARTITION_BIOS=""  # let this empty if you have an EFI system
    PARTITION_BOOT=""
    PARTITION_ROOT="" 

When setting `ERASE` to false, `DEVICE` variable is ignored, otherwise, `PARTITION_BIOS`, `PARTITION_BOOT` and `PARTITION_ROOT` are ignored.

`check_variables()` has also been updated to ensure `PARTITION_BIOS` is correctly set on BIOS system.

Moreover, i upadated encrypt options to use `aes-xts-plain64` cipher (based on `cryptsetup benchmark`) and `--align-payload=8192` option (based on [this explanation](https://www.spinics.net/lists/dm-crypt/msg02421.html))