### PR TITLE
Fix/syntax

### DIFF
--- a/alis.conf
+++ b/alis.conf
@@ -7,8 +7,17 @@
 KEYS="es"
 LOG="false"
 
-# partition
+# Partition
+ERASE="false" # If true, partitions will be automatically created
+
+# Required if ERASE is true
 DEVICE="/dev/sda !/dev/nvme0n1 !/dev/mmcblk0" # sata nvme mmc (single)
+
+# Required if ERASE is false
+PARTITION_BIOS=""  # let this empty if you have an EFI system
+PARTITION_BOOT="/dev/sda1"
+PARTITION_ROOT="/dev/sda2"
+
 DEVICE_TRIM="true" # If DEVICE supports TRIM
 LVM="true" # true if use LVM for partitioning
 PARTITION_ROOT_ENCRYPTION_PASSWORD="archlinux" # LUKS encryption key, if LVM will be user LVM on LUKS. Empty for not use LUKS/encryption. Warning: change it!

--- a/alis.sh
+++ b/alis.sh
@@ -492,7 +492,7 @@ function partition() {
     fi
 
     if [ -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" ]; then
-        echo -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" | cryptsetup --key-size=512 --key-file=- luksFormat --type luks2 $PARTITION_ROOT
+        echo -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" | cryptsetup --key-size=512 --key-file=- --align-payload=8192 -s 256 -c aes-xts-plain64 luksFormat --type luks2 $PARTITION_ROOT
         echo -n "$PARTITION_ROOT_ENCRYPTION_PASSWORD" | cryptsetup --key-file=- open $PARTITION_ROOT $LVM_VOLUME_PHISICAL
         sleep 5
     fi

--- a/alis.sh
+++ b/alis.sh
@@ -607,7 +607,7 @@ function mkinitcpio_configuration() {
         pacman_install "btrfs-progs"
     fi
 
-    if ["$BOOTLOADER" == "systemd"]; then
+    if [ "$BOOTLOADER" == "systemd" ]; then
         HOOKS=$(echo $HOOKS | sed 's/!systemd/systemd/')
         if [ "$LVM" == "true" ]; then
             HOOKS=$(echo $HOOKS | sed 's/!sd-lvm2/sd-lvm2/')

--- a/alis.sh
+++ b/alis.sh
@@ -513,6 +513,7 @@ function partition() {
         PARTITION_OPTIONS="$PARTITION_OPTIONS,noatime"
     fi
 
+    partition_mount
     partition_swap
 
     # set variables


### PR DESCRIPTION
Fix missing spaces inside a if brackets pair, causing bash to interpret `$BOOTLOADER` variable as a command.