### PR TITLE
Update alis.sh

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -294,7 +294,7 @@ function facts() {
 
 function check_facts() {
     if [ "$BIOS_TYPE" == "bios" ]; then
-        check_variables_list "BOOTLOADER" "$BOOTLOADER" "grub"
+        check_variables_list "BOOTLOADER" "$BOOTLOADER" "grub refind systemd"
     fi
 }
 


### PR DESCRIPTION
error caused when refind and systemd are missing from the list of bootloaders Line 297.

Reference: Setting configuration for systemd-boot fails with error #96