### PR TITLE
Add linux-firmware to the install base

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -548,7 +548,7 @@ function install() {
     sed -i 's/#Color/Color/' /etc/pacman.conf
     sed -i 's/#TotalDownload/TotalDownload/' /etc/pacman.conf
 
-    pacstrap /mnt base base-devel linux
+    pacstrap /mnt base base-devel linux linux-firmware
 
     sed -i 's/#Color/Color/' /mnt/etc/pacman.conf
     sed -i 's/#TotalDownload/TotalDownload/' /mnt/etc/pacman.conf


### PR DESCRIPTION
Good evening! I recently installed a new Arch system. This script was a massive help. Thank you!

I ran into this this bug during the installation.

Apparently, `linux-firmware` used to be a dependency of `linux` and so would be installed automatically, but they were separated at some point.

Without it, installing on a VM still works, but when I tried to install on bare metal (Intel CPU and AMD GPU) it froze during bootup. Adding the `linux-firmware` package fixed this.

See https://wiki.archlinux.org/index.php/Installation_guide#Install_essential_packages