### PR TITLE
Add support for installing i3wm desktop environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For new features, improvements and bugs fill an issue in GitHub or make a pull r
 * Partition: no LVM, LVM, LVM on LUKS, GPT on UEFI, MBR on BIOS
 * File system: ext4, btrfs (with subvols), xfs
 * Kernels: linux-lts, linux-hardened, linux-zen
-* Desktop environment: GNOME, KDE, XFCE, Mate, Cinnamon, LXDE
+* Desktop environment: GNOME, KDE, XFCE, Mate, Cinnamon, LXDE, i3-wm, i3-gaps
 * Display managers: GDM, SDDM, Lightdm, lxdm
 * Graphics controller: intel, nvidia and amd with optionally early KMS start. With intel optionally fastboot, hardware video acceleration and framebuffer compression.
 * Bootloader: GRUB, rEFInd, systemd-boot
@@ -48,7 +48,7 @@ For new features, improvements and bugs fill an issue in GitHub or make a pull r
 * AUR utility installation (aurman, yay)
 * Script for download installation and recovery scripts and configuration files
 * Retry packages download on connection/mirror error
-* Desktop environments (GDM, KDE, XFCE, Mate, Cinnamon, LXDE), display managers (GDM, SDDM, Lightdm, lxdm) and no desktop environment
+* Desktop environments (GDM, KDE, XFCE, Mate, Cinnamon, LXDE, i3-wm, i3-gaps), display managers (GDM, SDDM, Lightdm, lxdm) and no desktop environment
 * Packer support for testing in VirtualBox
 * Installation log with all commands executed and output in a file and/or asciinema video
 * Wait after installation for an abortable reboot
@@ -193,5 +193,6 @@ https://www.archlinux.org/download/
 * https://wiki.archlinux.org/index.php/GNOME
 * https://wiki.archlinux.org/index.php/KDE
 * https://wiki.archlinux.org/index.php/Xfce
+* https://wiki.archlinux.org/index.php/I3
 * http://tldp.org/LDP/Bash-Beginners-Guide/html/
 * http://tldp.org/LDP/abs/html/

--- a/alis.conf
+++ b/alis.conf
@@ -72,7 +72,7 @@ HOOKS="base !udev !usr !resume !systemd !btrfs keyboard autodetect modconf block
 BOOTLOADER="!grub !refind systemd" # (single)
 
 # desktop
-DESKTOP_ENVIRONMENT="!gnome !kde !xfce !mate !cinnamon !lxde !i3wm" # (single)
+DESKTOP_ENVIRONMENT="!gnome !kde !xfce !mate !cinnamon !lxde !i3-wm !i3-gaps" # (single)
 DISPLAY_DRIVER="!intel !amdgpu !ati !nvidia !nvidia-lts !nvidia-dkms !nvidia-390xx !nvidia-390xx-lts !nvidia-390xx-dkms !nouveau" # (single)
 KMS="true"
 FASTBOOT="true"

--- a/alis.conf
+++ b/alis.conf
@@ -72,7 +72,7 @@ HOOKS="base !udev !usr !resume !systemd !btrfs keyboard autodetect modconf block
 BOOTLOADER="!grub !refind systemd" # (single)
 
 # desktop
-DESKTOP_ENVIRONMENT="!gnome !kde !xfce !mate !cinnamon !lxde" # (single)
+DESKTOP_ENVIRONMENT="!gnome !kde !xfce !mate !cinnamon !lxde !i3wm" # (single)
 DISPLAY_DRIVER="!intel !amdgpu !ati !nvidia !nvidia-lts !nvidia-dkms !nvidia-390xx !nvidia-390xx-lts !nvidia-390xx-dkms !nouveau" # (single)
 KMS="true"
 FASTBOOT="true"

--- a/alis.sh
+++ b/alis.sh
@@ -160,7 +160,7 @@ function check_variables() {
     check_variables_value "HOOKS" "$HOOKS"
     check_variables_list "BOOTLOADER" "$BOOTLOADER" "grub refind systemd"
     check_variables_list "AUR" "$AUR" "aurman yay" "false"
-    check_variables_list "DESKTOP_ENVIRONMENT" "$DESKTOP_ENVIRONMENT" "gnome kde xfce mate cinnamon lxde" "false"
+    check_variables_list "DESKTOP_ENVIRONMENT" "$DESKTOP_ENVIRONMENT" "gnome kde xfce mate cinnamon lxde i3wm" "false"
     check_variables_list "DISPLAY_DRIVER" "$DISPLAY_DRIVER" "intel amdgpu ati nvidia nvidia-lts nvidia-dkms nvidia-390xx nvidia-390xx-lts nvidia-390xx-dkms nouveau" "false"
     check_variables_boolean "KMS" "$KMS"
     check_variables_boolean "FASTBOOT" "$FASTBOOT"
@@ -1267,6 +1267,9 @@ function desktop_environment() {
         "lxde" )
             desktop_environment_lxde
             ;;
+        "i3wm" )
+            desktop_environment_i3wm
+            ;;
     esac
 
     arch-chroot /mnt systemctl set-default graphical.target
@@ -1300,6 +1303,11 @@ function desktop_environment_cinnamon() {
 function desktop_environment_lxde() {
     pacman_install "lxde lxdm"
     arch-chroot /mnt systemctl enable lxdm.service
+}
+
+function desktop_environment_i3wm() {
+    pacman_install "i3 dmenu rxvt-unicode lightdm lightdm-gtk-greeter xorg-server"
+    arch-chroot /mnt systemctl enable lightdm.service
 }
 
 function packages() {

--- a/alis.sh
+++ b/alis.sh
@@ -160,7 +160,7 @@ function check_variables() {
     check_variables_value "HOOKS" "$HOOKS"
     check_variables_list "BOOTLOADER" "$BOOTLOADER" "grub refind systemd"
     check_variables_list "AUR" "$AUR" "aurman yay" "false"
-    check_variables_list "DESKTOP_ENVIRONMENT" "$DESKTOP_ENVIRONMENT" "gnome kde xfce mate cinnamon lxde i3wm" "false"
+    check_variables_list "DESKTOP_ENVIRONMENT" "$DESKTOP_ENVIRONMENT" "gnome kde xfce mate cinnamon lxde i3-wm i3-gaps" "false"
     check_variables_list "DISPLAY_DRIVER" "$DISPLAY_DRIVER" "intel amdgpu ati nvidia nvidia-lts nvidia-dkms nvidia-390xx nvidia-390xx-lts nvidia-390xx-dkms nouveau" "false"
     check_variables_boolean "KMS" "$KMS"
     check_variables_boolean "FASTBOOT" "$FASTBOOT"
@@ -1267,8 +1267,11 @@ function desktop_environment() {
         "lxde" )
             desktop_environment_lxde
             ;;
-        "i3wm" )
-            desktop_environment_i3wm
+        "i3-wm" )
+            desktop_environment_i3_wm
+            ;;
+        "i3-gaps" )
+            desktop_environment_i3_gaps
             ;;
     esac
 
@@ -1305,8 +1308,13 @@ function desktop_environment_lxde() {
     arch-chroot /mnt systemctl enable lxdm.service
 }
 
-function desktop_environment_i3wm() {
-    pacman_install "i3 dmenu rxvt-unicode lightdm lightdm-gtk-greeter xorg-server"
+function desktop_environment_i3_wm() {
+    pacman_install "i3-wm i3blocks i3lock i3status dmenu rxvt-unicode lightdm lightdm-gtk-greeter xorg-server"
+    arch-chroot /mnt systemctl enable lightdm.service
+}
+
+function desktop_environment_i3_gaps() {
+    pacman_install "i3-gaps i3blocks i3lock i3status dmenu rxvt-unicode lightdm lightdm-gtk-greeter xorg-server"
     arch-chroot /mnt systemctl enable lightdm.service
 }
 

--- a/packer/alis-packer-efi-ext4-grub-i3-wm.json
+++ b/packer/alis-packer-efi-ext4-grub-i3-wm.json
@@ -1,0 +1,50 @@
+{
+    "variables": {
+      "iso": "https://mirror.rackspace.com/archlinux/iso/latest/archlinux-2020.09.01-x86_64.iso",
+      "disk_size": "16384"
+    },
+    "builders": [
+      {
+        "name": "archlinux-alis-virtualbox",
+        "type": "virtualbox-iso",
+        "guest_os_type": "ArchLinux_64",
+        "guest_additions_mode": "attach",
+        "headless": false,
+        "http_directory": ".",
+        "vboxmanage": [
+          ["modifyvm", "{{.Name}}", "--memory", "2048"],
+          ["modifyvm", "{{.Name}}", "--vram", "128"],
+          ["modifyvm", "{{.Name}}", "--cpus", "2"],
+          ["modifyvm", "{{.Name}}", "--firmware", "efi"]
+        ],
+        "disk_size": "{{user `disk_size`}}",
+        "hard_drive_interface": "sata",
+        "iso_url": "{{user `iso`}}",
+        "iso_checksum": "sha1:95ebacd83098b190e8f30cc28d8c57af0d0088a0",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_wait_timeout": "60m",
+        "boot_wait": "5s",
+        "boot_command": [
+          "<wait30s>",
+          "curl -O http://{{.HTTPIP}}:{{.HTTPPort}}/alis.conf<enter><wait1s>",
+          "curl -O http://{{.HTTPIP}}:{{.HTTPPort}}/alis.sh<enter><wait1s>",
+          "sed -i \"s/LVM=.*/LVM=\\\"false\\\"/\" ./alis.conf<enter><wait1s>",
+          "sed -i \"s/LUKS_PASSWORD=.*/LUKS_PASSWORD=\\\"\\\"/\" ./alis.conf<enter><wait1s>",
+          "sed -i \"s/LUKS_PASSWORD_RETYPE=.*/LUKS_PASSWORD_RETYPE=\\\"\\\"/\" ./alis.conf<enter><wait1s>",
+          "sed -i \"s/BOOTLOADER=.*/BOOTLOADER=\\\"grub\\\"/\" ./alis.conf<enter><wait1s>",
+          "sed -i \"s/DESKTOP_ENVIRONMENT=.*/DESKTOP_ENVIRONMENT=\\\"i3-wm\\\"/\" ./alis.conf<enter><wait1s>",
+          "chmod +x ./alis.sh<enter><wait1s>",
+          "./alis.sh<enter><wait3>y<wait1s><enter>",
+          "<wait10s><wait10s><wait10s><wait10s><wait10s><wait10s><wait10s><wait60m>"
+        ],
+        "shutdown_command": "systemctl poweroff"
+      }
+    ],
+    "post-processors": [
+      {
+        "type": "vagrant",
+        "output": "archlinux-alis-{{.BuildName}}.box"
+      }
+    ]
+  }

--- a/site/content/index.markdown
+++ b/site/content/index.markdown
@@ -96,7 +96,7 @@ url: "/"
         <li>Optional file swap (not supported in btrfs)</li>
         <li>Storage: SATA, NVMe and MMC</li>
         <li>Kernels: linux-lts, linux-hardened, linux-zen</li>
-        <li>Desktop environment: GNOME, KDE, XFCE, Mate, Cinnamon, LXDE</li>
+        <li>Desktop environment: GNOME, KDE, XFCE, Mate, Cinnamon, LXDE, i3-wm, i3-gaps</li>
         <li>Display managers: GDM, SDDM, Lightdm, lxdm</li>
         <li>Graphics controller: intel, nvidia, amd with optionally early KMS start</li>
         <li>Bootloader: GRUB, rEFInd, systemd-boot</li>


### PR DESCRIPTION
This installs the whole i3 group, so includes i3lock and i3status. I've also included a default terminal so that you have something that works out of the box, and lightdm so that you get a greeter.

I based this heavily on how I saw the other desktop environments like xfce were implemented.