### PR TITLE
Add paru as an AUR alternative

### DIFF
--- a/alis-packages.conf
+++ b/alis-packages.conf
@@ -48,7 +48,7 @@ PACKAGES_SDKMAN_SDKS="!gradle !maven !kotlin !groovy" # format <candidate>:[vers
 ## AUR utility and packages to install
 ## more at https://aur.archlinux.org/packages/
 PACKAGES_AUR_INSTALL="false"
-PACKAGES_AUR_COMMAND="yay !aurman"
+PACKAGES_AUR_COMMAND="paru !yay !aurman"
 PACKAGES_AUR_INTERNET=""
 PACKAGES_AUR_MULTIMEDIA=""
 PACKAGES_AUR_UTILITIES=""

--- a/alis-packages.sh
+++ b/alis-packages.sh
@@ -43,7 +43,7 @@ set -e
 # # vim alis-packages.conf
 # # sudo ./alis-packages.sh
 
-# enviroment variables 
+# enviroment variables
 #USER_NAME=""
 #USER_PASSWORD=""
 
@@ -85,7 +85,7 @@ function check_variables() {
     check_variables_boolean "PACKAGES_FLATPAK_INSTALL" "$PACKAGES_FLATPAK_INSTALL"
     check_variables_boolean "PACKAGES_SDKMAN_INSTALL" "$PACKAGES_SDKMAN_INSTALL"
     check_variables_boolean "PACKAGES_AUR_INSTALL" "$PACKAGES_AUR_INSTALL"
-    check_variables_list "PACKAGES_AUR_COMMAND" "$PACKAGES_AUR_COMMAND" "yay aurman" "true"
+    check_variables_list "PACKAGES_AUR_COMMAND" "$PACKAGES_AUR_COMMAND" "paru yay aurman" "true"
 }
 
 function check_variables_value() {
@@ -239,6 +239,9 @@ function packages_aur() {
         pacman_install "git"
 
         case "$PACKAGES_AUR_COMMAND" in
+            "paru" | *)
+                execute_aur "rm -rf /home/$USER_NAME/.alis/aur/$PACKAGES_AUR_COMMAND && mkdir -p /home/$USER_NAME/.alis/aur && cd /home/$USER_NAME/.alis/aur && git clone https://aur.archlinux.org/$PACKAGES_AUR_COMMAND.git && (cd $PACKAGES_AUR_COMMAND && makepkg -si --noconfirm) && rm -rf /home/$USER_NAME/.alis/aur/$PACKAGES_AUR_COMMAND"
+                ;;
             "aurman" )
                 execute_aur "rm -rf /home/$USER_NAME/.alis/aur/$PACKAGES_AUR_COMMAND && mkdir -p /home/$USER_NAME/.alis/aur && cd /home/$USER_NAME/.alis/aur && git clone https://aur.archlinux.org/$PACKAGES_AUR_COMMAND.git && gpg --recv-key 465022E743D71E39 && (cd $PACKAGES_AUR_COMMAND && makepkg -si --noconfirm) && rm -rf /home/$USER_NAME/.alis/aur/$PACKAGES_AUR_COMMAND"
                 ;;


### PR DESCRIPTION
As the main yay developer is leaving yay behind and focusing on paru (written in rust) and already hit version 1.0, It is a good alternative to yay.

You can see the main developer talking about para right here:
https://www.reddit.com/r/archlinux/comments/jjn1c1/paru_v100_and_stepping_away_from_yay/


<hr>

@picodotdev:
paru requires to install rust before? as yay requires to install go
Is this not necessary gpg --recv-key 465022E743D71E39?

Not necessary, at least with latest Arch iso


@picodotdev:
Which advantages has paru over yay for setting it as default?

Actively mantained, colored output, flip search order, you can edit AUR packages through paru, written in rust ;), etc...
