### PR TITLE
enable virtual additions to work

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -1038,6 +1038,7 @@ function virtualbox() {
     else
         pacman_install "virtualbox-guest-utils virtualbox-guest-dkms"
     fi
+    arch-chroot /mnt systemctl enable vboxservice
 }
 
 function users() {


### PR DESCRIPTION
This enable the vboxservice so the Virtual Box additions can function fully.