### PR TITLE
Handle case where existing lv and vg  is found

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -346,7 +346,8 @@ function prepare_partition() {
         umount /mnt
     fi
     if [ -e "/dev/mapper/$LVM_VOLUME_GROUP-$LVM_VOLUME_LOGICAL" ]; then
-        umount "/dev/mapper/$LVM_VOLUME_GROUP-$LVM_VOLUME_LOGICAL"
+        lvmremove "/dev/$LVM_VOLUME_GROUP/$LVM_VOLUME_LOGICAL"
+        vgremove "/dev/$LVM_VOLUME_GROUP"
     fi
     if [ -e "/dev/mapper/$LUKS_DEVICE_NAME" ]; then
         cryptsetup close $LUKS_DEVICE_NAME

--- a/alis.sh
+++ b/alis.sh
@@ -346,7 +346,7 @@ function prepare_partition() {
         umount /mnt
     fi
     if [ -e "/dev/mapper/$LVM_VOLUME_GROUP-$LVM_VOLUME_LOGICAL" ]; then
-        lvmremove "/dev/$LVM_VOLUME_GROUP/$LVM_VOLUME_LOGICAL"
+        lvremove "/dev/$LVM_VOLUME_GROUP/$LVM_VOLUME_LOGICAL"
         vgremove "/dev/$LVM_VOLUME_GROUP"
     fi
     if [ -e "/dev/mapper/$LUKS_DEVICE_NAME" ]; then


### PR DESCRIPTION
This will handle the case if an existing `logical volume` and `volume group` are found of the same name as have been requested for the install.

It removes the logical volume and the volume group before going on to successful complete the install.

I think this would be the desired outcome.