### PR TITLE
remove kde-applications-meta in favor of plasma-meta

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -1595,7 +1595,7 @@ function desktop_environment_gnome() {
 }
 
 function desktop_environment_kde() {
-    pacman_install "plasma-meta plasma-wayland-session"
+    pacman_install "plasma-meta plasma-wayland-session konsole kate dolphin"
     arch-chroot /mnt systemctl enable sddm.service
 }
 

--- a/alis.sh
+++ b/alis.sh
@@ -1595,7 +1595,7 @@ function desktop_environment_gnome() {
 }
 
 function desktop_environment_kde() {
-    pacman_install "plasma-meta plasma-wayland-session kde-applications-meta"
+    pacman_install "plasma-meta plasma-wayland-session"
     arch-chroot /mnt systemctl enable sddm.service
 }
 


### PR DESCRIPTION
This fixes and tidy up some bloat as `kde-applications-meta` contains KDE Games and KDE education applications which should not be the part of default installation. `plasma-meta` has all the default KDE applications required. Thanks for the great script !