### PR TITLE
Added vulkan loaders as required.

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -946,35 +946,35 @@ function display_driver() {
                 PACKAGES_VULKAN_MULTILIB="lib32-vulkan-icd-loader lib32-vulkan-intel"
                 ;;
             "amdgpu" )
-                PACKAGES_VULKAN="vulkan-radeon"
-                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-radeon"
+                PACKAGES_VULKAN="vulkan-icd-loader vulkan-radeon"
+                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-icd-loader lib32-vulkan-radeon"
                 ;;
             "ati" )
-                PACKAGES_VULKAN="vulkan-radeon"
-                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-radeon"
+                PACKAGES_VULKAN="vulkan-icd-loader vulkan-radeon"
+                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-icd-loader lib32-vulkan-radeon"
                 ;;
             "nvidia" )
-                PACKAGES_VULKAN="nvidia-utils"
-                PACKAGES_VULKAN_MULTILIB="lib32-nvidia-utils"
+                PACKAGES_VULKAN="vulkan-icd-loader nvidia-utils"
+                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-icd-loader lib32-nvidia-utils"
                 ;;
             "nvidia-lts" )
-                PACKAGES_VULKAN="nvidia-utils"
-                PACKAGES_VULKAN_MULTILIB="lib32-nvidia-utils"
+                PACKAGES_VULKAN="vulkan-icd-loader nvidia-utils"
+                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-icd-loader lib32-nvidia-utils"
                 ;;
             "nvidia-dkms" )
-                PACKAGES_VULKAN="nvidia-utils"
-                PACKAGES_VULKAN_MULTILIB="lib32-nvidia-utils"
+                PACKAGES_VULKAN="vulkan-icd-loader nvidia-utils"
+                PACKAGES_VULKAN_MULTILIB="lib32-vulkan-icd-loader lib32-nvidia-utils"
                 ;;
             "nvidia-390xx" )
-                PACKAGES_VULKAN="nvidia-utils"
+                PACKAGES_VULKAN="vulkan-icd-loader nvidia-utils"
                 PACKAGES_VULKAN_MULTILIB=""
                 ;;
             "nvidia-390xx-lts" )
-                PACKAGES_VULKAN="nvidia-utils"
+                PACKAGES_VULKAN="vulkan-icd-loader nvidia-utils"
                 PACKAGES_VULKAN_MULTILIB=""
                 ;;
             "nvidia-390xx-dkms" )
-                PACKAGES_VULKAN="nvidia-utils"
+                PACKAGES_VULKAN="vulkan-icd-loader nvidia-utils"
                 PACKAGES_VULKAN_MULTILIB=""
                 ;;
             "nouveau" )


### PR DESCRIPTION
This PR adds vulkan-icd-loader and lib32-vulkan-icd-loader which are required for Vulkan support 

https://wiki.archlinux.org/title/Vulkan#Installation

The reason for mentioning loaders is because if it is not mentioned it will install vulkan-icd-loader as a build dependency (make) in case of vulkan-radeon for example. And if someone removes the make dependencies vulkan-icd-loader gets removed as well.