### PR TITLE
Populate pacman keys after pacstrap.

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -742,6 +742,8 @@ function configuration() {
     arch-chroot /mnt locale-gen
     echo -e "$KEYMAP\n$FONT\n$FONT_MAP" > /mnt/etc/vconsole.conf
     echo $HOSTNAME > /mnt/etc/hostname
+    
+    pacman-key --populate
 
     OPTIONS=""
     if [ -n "$KEYLAYOUT" ]; then


### PR DESCRIPTION
Needed to add this step to get around missing keys when adding user packages.