### PR TITLE
Add support for Suggested filesystem layout in Btrfs Snapper

### DIFF
--- a/alis.conf
+++ b/alis.conf
@@ -32,6 +32,7 @@ LVM="false"
 LUKS_PASSWORD=""
 LUKS_PASSWORD_RETYPE=""
 FILE_SYSTEM_TYPE="ext4 !btrfs !xfs !f2fs !reiserfs" # (single)
+BTRFS_SNAPPER_SUGGESTED_FILESYSTEM_LAYOUT="true"
 SWAP_SIZE="!2048 !4096 !8192" # (single)
 PARTITION_MODE="auto !custom !manual"
 PARTITION_CUSTOM_PARTED_UEFI="mklabel gpt mkpart ESP fat32 1MiB 512MiB mkpart root $FILE_SYSTEM_TYPE 512MiB 100% set 1 esp on"

--- a/alis.sh
+++ b/alis.sh
@@ -680,7 +680,7 @@ function partition() {
 
             # swap
             if [ -n "$SWAP_SIZE" ]; then
-                mkdir /mnt/swap
+                mkdir -m 0700 /mnt/swap
                 mount -o "subvol=@swap,$PARTITION_OPTIONS_ROOT,compress=zstd" "$DEVICE_ROOT" /mnt/swap
                 truncate -s 0 /mnt/swap$SWAPFILE
                 chattr +C /mnt/swap$SWAPFILE


### PR DESCRIPTION
This is my first pull request. It has been tested, but you can modify it and use it as you like.

- alis.conf: BTRFS_SNAPPER_SUGGESTED_FILESYSTEM_LAYOUT="true"
- Reference: https://wiki.archlinux.org/title/Snapper#Suggested_filesystem_layout

After rebooting, you can use the following command to create a Snapper snapshot.

```bash
# root user
# basic config
umount /.snapshots
rm -Rf /.snapshots
pacman -S snapper
snapper -c root create-config /
mount -a
chmod 750 /.snapshots

# make snapshot
snapper -c root create
snapper -c root list

# service
systemctl enable --now snapper-boot.timer snapper-timeline.timer snapper-cleanup.timer
```