### PR TITLE
Added pipewire-alsa and wireplumber as default if pipewire is selected

### DIFF
--- a/alis-packages.conf
+++ b/alis-packages.conf
@@ -32,7 +32,7 @@ PACKAGES_PACMAN_SCIENCE="!geogebra !octave"
 PACKAGES_PACMAN_OTHERS="!klavaro !tmux"
 PACKAGES_PACMAN_DEVELOPER="!git !python !dotnet-sdk !php !rust !go !virtualbox !docker !ansible !vagrant !packer !terraform !vault !consul !nomad"
 PACKAGES_PACMAN_CUSTOM=""
-PACKAGES_PACMAN_PIPEWIRE="pipewire pipewire-pulse !pipewire-jack !pipewire-alsa !helvum !wireplumber !xdg-desktop-portal !xdg-desktop-portal-gnome !xdg-desktop-portal-kde !xdg-desktop-portal-wlr"
+PACKAGES_PACMAN_PIPEWIRE="pipewire pipewire-pulse !pipewire-jack pipewire-alsa !helvum wireplumber !xdg-desktop-portal !xdg-desktop-portal-gnome !xdg-desktop-portal-kde !xdg-desktop-portal-wlr"
 PACKAGES_PACMAN_CUSTOM_REPOSITORIES="
 #[custom]
 #SigLevel = Optional TrustAll


### PR DESCRIPTION
pipewire-alsa is required otherwise users might be left without audio on many applications. Wireplumber has replaced pipewire-media-session as the default session manager and pipewire-media-session has been deprecated by freedesktop.org so wireplumber is now the preferred session manager for desktop audio.

Change has been done in Archinstall
https://github.com/archlinux/archinstall/pull/914

And Fedora 
https://fedoraproject.org/wiki/Changes/WirePlumber

