### PR TITLE
Fix btrfs swapfile creation

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -580,8 +580,7 @@ function partition() {
         if [ "$FILE_SYSTEM_TYPE" == "btrfs" ]; then
             SWAPFILE="${BTRFS_SUBVOLUME_SWAP[2]}${SWAPFILE}"
             truncate -s 0 ${MNT_DIR}${SWAPFILE}
-            chattr +C ${MNT_DIR}${SWAPFILE}
-            btrfs property set ${MNT_DIR}${SWAPFILE} compression none
+            chattr +C ${MNT_DIR}
         fi
 
         dd if=/dev/zero of=${MNT_DIR}${SWAPFILE} bs=1M count=$SWAP_SIZE status=progress


### PR DESCRIPTION
Reflects the following ArchWiki changes:

https://wiki.archlinux.org/index.php?title=Btrfs&type=revision&diff=731997&oldid=731247

Before the modification, the following error occurs:

```
++ truncate -s 0 /mnt/swap/swapfile
++ chattr +C /mnt/swap/swapfile
++ btrfs property set /mnt/swap/swapfile compression none
ERROR: failed to set compression for /mnt/swap/swapfile: Invalid argument
```
