### PR TITLE
Remove process of creating zero-length swap file

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -579,7 +579,6 @@ function partition() {
     if [ -n "$SWAP_SIZE" ]; then
         if [ "$FILE_SYSTEM_TYPE" == "btrfs" ]; then
             SWAPFILE="${BTRFS_SUBVOLUME_SWAP[2]}${SWAPFILE}"
-            truncate -s 0 ${MNT_DIR}${SWAPFILE}
             chattr +C ${MNT_DIR}
         fi
 


### PR DESCRIPTION
Reflects the following ArchWiki changes:

https://wiki.archlinux.org/index.php?title=Btrfs&type=revision&diff=731997&oldid=731247

I had missed the following part.
> There is no need to create zero-length files in order to set the No_COW attribute when you can chattr the whole parent directory

I did test it. It appears to be working correctly.