### PR TITLE
Implemented measure against pacman keyring initialization problems.

### DIFF
--- a/alis.sh
+++ b/alis.sh
@@ -560,6 +560,10 @@ function install() {
     print_step "install()"
     local COUNTRIES=()
 
+    while [ "$(systemctl is-active multi-user.target)" == "inactive" ]; do
+        sleep 1
+    done
+
     pacman-key --init
     pacman-key --populate
 


### PR DESCRIPTION
When experimenting with headless installations (in combination with network booting) using the script on VMs, very often I had troubles with the commands `pacman-key --init` and `pacman-key --populate` resulting in errors. From what I understand from the journal (see attachments) there is a racing condition between systemd starting a refresh of the PGP keys of archlinux-keyring and the commands issued by the script.

The few lines of code added prevent this racing condition to be met.

[alis.conf.txt](https://github.com/picodotdev/alis/files/11826614/alis.conf.txt)
[alis.log.txt](https://github.com/picodotdev/alis/files/11826616/alis.log.txt)
[journal.log.txt](https://github.com/picodotdev/alis/files/11826619/journal.log.txt)
