### PR TITLE
Change UEFI boot option to fmask=0177

### DIFF
--- a/alis-commons.sh
+++ b/alis-commons.sh
@@ -424,7 +424,7 @@ function partition_options() {
     PARTITION_OPTIONS="defaults"
 
     if [ "$BIOS_TYPE" == "uefi" ]; then
-        PARTITION_OPTIONS_BOOT="$PARTITION_OPTIONS_BOOT,uid=0,gid=0,fmask=0077,dmask=0077"
+        PARTITION_OPTIONS_BOOT="$PARTITION_OPTIONS_BOOT,uid=0,gid=0,fmask=0177,dmask=0077"
     fi
     if [ "$DEVICE_TRIM" == "true" ]; then
         PARTITION_OPTIONS_BOOT="$PARTITION_OPTIONS_BOOT,noatime"


### PR DESCRIPTION
If the mount option `fmask=0077` is present on the /boot partition, the following error occurs during boot.

```
bootctl[417]:  Mount point '/boot' which backs the random seed file is world accessible, which is a security hole!
bootctl[417]: Random seed file '/boot/loader/random-seed' is world accessible, which is a security hole!
```

The modified `fmask=0177` is described below.

https://wiki.archlinux.org/title/Fstab#Usage